### PR TITLE
페이지 공통 레이아웃 추가(영역 분할)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,33 +1,26 @@
-import { Switch, Route, Link } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 
-import { Header, Container } from './styles/Page';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import WorksPage from './pages/WorksPage';
 import ShopPage from './pages/ShopPage';
 import CartPage from './pages/CartPage';
 import NotFoundPage from './pages/NotFoundPage';
-import MenuBar from './components/MenuBar';
 
 export default function App() {
   return (
-    <Container>
-      <Header>
-        <h1>
-          <Link to="/">STUDIO XX</Link>
-        </h1>
-        <MenuBar />
-      </Header>
-      <Switch>
-        <Route exact path="/" component={HomePage} />
-        <Route path="/login" component={LoginPage} />
-        <Route path="/works/:id" component={WorksPage} />
-        <Route exact path="/works" component={WorksPage} />
-        <Route path="/shop/items/:id" component={ShopPage} />
-        <Route path="/shop/items/" component={ShopPage} />
-        <Route path="/cart" component={CartPage} />
-        <Route component={NotFoundPage} />
-      </Switch>
-    </Container>
+
+    <Switch>
+      <Route exact path="/" component={HomePage} />
+      <Route path="/login" component={LoginPage} />
+      <Route path="/works/:id" component={WorksPage} />
+      <Route exact path="/works" component={WorksPage} />
+      <Route path="/shop/items/:id" component={ShopPage} />
+      <Route path="/shop/items/" component={ShopPage} />
+      <Route path="/cart" component={CartPage} />
+      <Route path="/test" component={HomePage} />
+      <Route component={NotFoundPage} />
+    </Switch>
+
   );
 }

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+import { Header } from '../styles/Page';
+import MenuBar from './MenuBar';
+
+function HeaderArea() {
+  return (
+    <Header>
+      <h1>
+        <Link to="/">STUDIO XX</Link>
+      </h1>
+      <MenuBar />
+    </Header>
+  );
+}
+
+function SubMenu({ title = '-', className }) {
+  if (title === 'home') { return null; }
+  return (
+    <div className={className}>
+      <p>{title}</p>
+    </div>
+  );
+}
+
+function ContentsArea({ className, contents }) {
+  return <div className={className}>{contents}</div>;
+}
+
+function FooterArea() {
+  const Footer = styled.footer({
+    backgroundColor: '#BBB',
+    margin: 0,
+    padding: '1em .5em',
+  });
+  return (
+    <Footer>
+      <p> 회사명 , 연락처, copyright 등</p>
+    </Footer>
+  );
+}
+
+const BodyArea = styled.main`
+  /* max-width: 1080px; */
+  min-width : 500px;
+  display: inline-block;
+  background-color: pink;
+  margin: auto;
+  display: grid;
+  grid-template-columns: 20vw auto; /* 각 행(세로줄)의 길이 */
+  grid-template-rows: 80vh; /* 각 열(가로줄)의 길이 */
+  gap: 10px; /* 자식요소간의 간격 */
+`;
+
+const NaviLeftArea = styled(SubMenu)({
+
+  backgroundColor: '#A3C',
+});
+
+export default function Layout({ title = '페이지 제목', className, children }) {
+  return (
+    <>
+      <HeaderArea />
+      <BodyArea>
+        <NaviLeftArea title={title} />
+        <ContentsArea className={className} contents={children} />
+      </BodyArea>
+      <FooterArea />
+    </>
+  );
+}

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -1,11 +1,12 @@
 import { Title } from '../styles/Page';
+import Layout from '../components/Layout';
 
-function HomePage() {
+function CartPage() {
   return (
-    <div>
+    <Layout title="cart">
       <Title> cart </Title>
-    </div>
+    </Layout>
   );
 }
 
-export default HomePage;
+export default CartPage;

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,10 +1,11 @@
 import { Title } from '../styles/Page';
+import Layout from '../components/Layout';
 
 function HomePage() {
   return (
-    <div>
+    <Layout title="home">
       <Title> home </Title>
-    </div>
+    </Layout>
   );
 }
 

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -1,11 +1,12 @@
 import { Title } from '../styles/Page';
+import Layout from '../components/Layout';
 
-function HomePage() {
+function LoginPage() {
   return (
-    <div>
+    <Layout title="login">
       <Title> login </Title>
-    </div>
+    </Layout>
   );
 }
 
-export default HomePage;
+export default LoginPage;

--- a/src/pages/ShopPage.jsx
+++ b/src/pages/ShopPage.jsx
@@ -1,11 +1,12 @@
 import { Title } from '../styles/Page';
+import Layout from '../components/Layout';
 
-function HomePage() {
+function ShopPage() {
   return (
-    <div>
+    <Layout title="shop">
       <Title> shop </Title>
-    </div>
+    </Layout>
   );
 }
 
-export default HomePage;
+export default ShopPage;

--- a/src/pages/WorksPage.jsx
+++ b/src/pages/WorksPage.jsx
@@ -1,11 +1,12 @@
 import { Title } from '../styles/Page';
+import Layout from '../components/Layout';
 
-function HomePage() {
+function WorkPage() {
   return (
-    <div>
+    <Layout title="works">
       <Title> works </Title>
-    </div>
+    </Layout>
   );
 }
 
-export default HomePage;
+export default WorkPage;

--- a/src/styles/Menu.jsx
+++ b/src/styles/Menu.jsx
@@ -4,6 +4,7 @@ const List = styled.ul({
   display: 'flex',
   justifyContent: 'flex-end',
   padding: '1em',
+  margin: 0,
   listStyle: 'none',
 });
 const Item = styled.li({

--- a/src/styles/Page.jsx
+++ b/src/styles/Page.jsx
@@ -14,10 +14,6 @@ const Header = styled.header({
     },
   },
 });
-const Container = styled.div({
-  width: '90%',
-  margin: '0 auto',
-});
 
 const Title = styled.h2({
   fontSize: '2em',
@@ -25,4 +21,4 @@ const Title = styled.h2({
   padding: '.4em 0',
 });
 
-export { Header, Container, Title };
+export { Header, Title };


### PR DESCRIPTION
레이아웃 컴포넌트를 추가하여,  컨텐츠 영역을 분할을 하였습니다.

home을 제외한 모든 페이지에서 같은 레이아웃을 사용합니다.

![스크린샷 2021-06-30 오후 11 48 34](https://user-images.githubusercontent.com/81964981/123982126-bdd8fe00-d9fd-11eb-8343-58107f74d8b9.png)
![스크린샷 2021-06-30 오후 11 48 43](https://user-images.githubusercontent.com/81964981/123982140-c03b5800-d9fd-11eb-9831-87cc0e699f64.png)


[자료 1 : 레이아웃 ](https://dev.to/julfikarhaidar/how-to-build-reusable-layouts-in-react-js-with-router-5gf7)
[자료 2 : 그리드 기초](https://studiomeal.com/archives/533)
[자료 3 : 그리드 응용 ](https://nykim.work/59)
[자료 4 : CSS 값 단위](https://developer.mozilla.org/ko/docs/Learn/CSS/Building_blocks/Values_and_units)