### PR TITLE
ShopPageListItem 클릭시 상세페이지로 이동 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/react": "^11.4.0",
         "@emotion/styled": "^11.3.0",
         "@reduxjs/toolkit": "^1.6.0",
+        "history": "^4.10.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@emotion/react": "^11.4.0",
     "@emotion/styled": "^11.3.0",
     "@reduxjs/toolkit": "^1.6.0",
+    "history": "^4.10.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,23 +4,22 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import WorksPage from './pages/WorksPage';
 import ShopPage from './pages/ShopPage';
+import ShopItemDetailPage from './pages/ShopItemDetailPage';
 import CartPage from './pages/CartPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
   return (
-
     <Switch>
       <Route exact path="/" component={HomePage} />
       <Route path="/login" component={LoginPage} />
       <Route path="/works/:id" component={WorksPage} />
       <Route exact path="/works" component={WorksPage} />
-      <Route path="/shop/items/:id" component={ShopPage} />
+      <Route path="/shop/items/:id" component={ShopItemDetailPage} />
       <Route path="/shop/items/" component={ShopPage} />
       <Route path="/cart" component={CartPage} />
       <Route path="/test" component={HomePage} />
       <Route component={NotFoundPage} />
     </Switch>
-
   );
 }

--- a/src/components/ShopPageListItem.jsx
+++ b/src/components/ShopPageListItem.jsx
@@ -30,12 +30,12 @@ const ItemTextSpan = styled.span(({ color = '#000', fontWeight = 'none' }) => ({
 
 export default function ShopPageListItem({ item }) {
   const {
-    img, name, realPrice, originPrice,
+    id, img, name, realPrice, originPrice,
   } = item;
 
   return (
     <GridItem>
-      <Link to="/shop/items">
+      <Link to={`/shop/items/${id}`}>
         <img src={img} alt={name} />
         <p>{name}</p>
         <ItemTextGroup>

--- a/src/components/ShopPageListItem.test.jsx
+++ b/src/components/ShopPageListItem.test.jsx
@@ -1,18 +1,19 @@
-import { render } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
 
 import ShopPageListItem from './ShopPageListItem';
 
 describe('ShopPageListItem', () => {
-  it('renders item infos', () => {
-    const item = {
-      id: 1,
-      name: '자석 마스크걸이',
-      originPrice: 2000,
-      realPrice: 1000,
-      img: 'https://test.com/img.jpg',
-    };
+  const item = {
+    id: 1,
+    name: '자석 마스크걸이',
+    originPrice: 2000,
+    realPrice: 1000,
+    img: 'https://test.com/img.jpg',
+  };
 
+  it('renders item infos', () => {
     const { container } = render(
       <MemoryRouter>
         <ShopPageListItem item={item} />
@@ -23,5 +24,22 @@ describe('ShopPageListItem', () => {
     expect(container).toHaveTextContent('1,000 원');
     expect(container).toHaveTextContent('2,000 원');
     expect(container).toHaveTextContent('50% 할인');
+  });
+
+  context('when click item', () => {
+    it('changes url & moves page', async () => {
+      const history = createMemoryHistory();
+      history.push = jest.fn();
+
+      const { getByText } = render(
+        <Router history={history}>
+          <ShopPageListItem item={item} />
+        </Router>,
+      );
+
+      fireEvent.click(getByText('자석 마스크걸이'));
+
+      expect(history.push).toHaveBeenCalledWith(`/shop/items/${item.id}`);
+    });
   });
 });

--- a/src/pages/ShopItemDetailPage.jsx
+++ b/src/pages/ShopItemDetailPage.jsx
@@ -1,0 +1,7 @@
+import { useParams } from 'react-router-dom';
+
+export default function ShopItemDetailPage({ params }) {
+  const { id } = params || useParams();
+
+  return <p>{`상품아이디 ${id} 상세보기 페이지`}</p>;
+}

--- a/src/pages/ShopItemDetailPage.test.jsx
+++ b/src/pages/ShopItemDetailPage.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import ShopItemDetailPage from './ShopItemDetailPage';
+
+describe('ShopItemDetailPage', () => {
+  it('renders page', () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ShopItemDetailPage />
+      </MemoryRouter>,
+    );
+
+    expect(container).toHaveTextContent('상세보기');
+  });
+});


### PR DESCRIPTION
판매상품 클릭시, 
상품 상세페이지로 이동합니다.

Link 컴포넌트 클릭시, 페이지 이동을 테스트 하기위해
[history](https://www.npmjs.com/package/history) 라이브러리를 설치하였습니다. 

[참고1 : 페이지 이동 테스트 작성법](https://stackoverflow.com/questions/61869886/simplest-test-for-react-routers-link-with-testing-library-react)

[참고2 : react-testing-library](https://testing-library.com/docs/example-react-router/)