### PR TITLE
CartPage 리팩토링 2 : 스타일 컴포넌트 분리, 단순 계산 함수 util로 이동

### DIFF
--- a/src/components/cart/CartAmountGroup.jsx
+++ b/src/components/cart/CartAmountGroup.jsx
@@ -1,55 +1,11 @@
-import styled from '@emotion/styled';
+import { currencyFomater, getSum, getPrices } from '../../util/commonUtils';
+import {
+  AmountBoxGruop,
+  AmountBox,
+  OrderButton,
+  Notice,
+} from '../../styles/CartPageStyle';
 
-import { currencyFomater } from '../../util/commonUtils';
-
-const AmountBoxGruop = styled.div({
-  width: '700px',
-  display: 'flex',
-  direction: 'row',
-  justifyContent: 'space-around',
-  marginTop: '40px',
-  // backgroundColor: 'palegreen',
-});
-const AmountBox = styled.div({
-  maxWidth: '100px',
-  alignItems: 'center',
-  display: 'flex',
-  flexDirection: 'column',
-  // backgroundColor: 'orange',
-  '& p': {
-    fontsize: '2em',
-  },
-  '& span': {
-    fontWeight: 'bolder',
-    fontsize: '1em',
-  },
-});
-const Button = styled.button({
-  backgroundColor: 'tomato',
-  color: 'white',
-  fontWeight: 'bold',
-  marginTop: '60px',
-  padding: '0.5rem 1rem',
-  fontSize: '1rem',
-  textAlign: 'center',
-  textDecoration: 'none',
-  display: 'inline-block',
-  width: '50%',
-  border: 'none',
-  borderRadius: '4px',
-});
-
-const Notice = styled.p({
-  color: '#C14',
-});
-
-function getSum(numbers) {
-  const sum = numbers.reduce((x, y) => x + y, 0);
-  return sum;
-}
-function getPrices(mCart) {
-  return mCart.map((item) => item.realPrice * item.itemAmount);
-}
 export default function CartAmountGroup({ cart }) {
   const sumPrices = getSum(getPrices(cart));
   const deliveryFee = sumPrices > 30000 ? 0 : 3000;
@@ -70,7 +26,7 @@ export default function CartAmountGroup({ cart }) {
           <span>{currencyFomater({ number: sumPrices + deliveryFee })}</span>
         </AmountBox>
       </AmountBoxGruop>
-      <Button type="button"> 주문하기</Button>
+      <OrderButton type="button"> 주문하기</OrderButton>
       <Notice> 30,000원 이하의 주문에는 배송비 3,000원이 추가됩니다.</Notice>
     </div>
   );

--- a/src/components/cart/CartContainer.jsx
+++ b/src/components/cart/CartContainer.jsx
@@ -1,16 +1,9 @@
 import { useDispatch } from 'react-redux';
-import styled from '@emotion/styled';
 
 import { changeCartItemCheked, removeSelectedCartIem } from '../../redux/slice';
 import CartItemTable from './CartItemsTable';
 import CartAmountGroup from './CartAmountGroup';
-
-const Container = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-});
+import { Container } from '../../styles/CartPageStyle';
 
 export default function CartContainer({ cart }) {
   const dispatch = useDispatch();

--- a/src/components/cart/CartItemRow.jsx
+++ b/src/components/cart/CartItemRow.jsx
@@ -1,43 +1,12 @@
-import styled from '@emotion/styled';
-
 import { currencyFomater } from '../../util/commonUtils';
-
-const Item = styled.tr({
-  // backgroundColor: 'ivory',
-  height: '100px',
-  marginTop: '10px',
-  display: 'flow',
-  '& div': {
-    // backgroundColor: 'red',
-    maxWidth: '500px',
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    alignItems: 'center',
-    '& img': {
-      margin: '10px',
-      width: '70px',
-    },
-    '& p': {
-      width: '300px',
-      whiteSpace: 'nowrap',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      display: 'block',
-      color: '#333',
-      textDecoration: 'none',
-      textAlign: 'center',
-      fontWeight: 'bolder',
-    },
-  },
-});
+import { ItemRow } from '../../styles/CartPageStyle';
 
 export default function CartItemRow({ item, onChangeCheckBox }) {
   const {
     id, name, img, itemAmount, realPrice, checked,
   } = item;
   return (
-    <Item>
+    <ItemRow>
       <td>
         <label htmlFor={`cartItem${id}`}>
           <input
@@ -64,6 +33,6 @@ export default function CartItemRow({ item, onChangeCheckBox }) {
         개
       </td>
       <td>{currencyFomater({ number: realPrice })}</td>
-    </Item>
+    </ItemRow>
   );
 }

--- a/src/components/cart/CartItemsTable.jsx
+++ b/src/components/cart/CartItemsTable.jsx
@@ -1,39 +1,10 @@
-import styled from '@emotion/styled';
-
 import CartItemRow from './CartItemRow';
-
-const Table = styled.table`
-  min-width: 700px;
-  margin-top: 40px;
-  position: relative;
-`;
-const Thead = styled.thead({
-  backgroundColor: '#ccc',
-  height: '40px',
-  fontWeight: 'bold',
-  fontSize: '17px',
-});
-const Tbody = styled.tbody`
-  text-align: center;
-  padding: 10px 0;
-  height: 20px;
-  font-size: 14px;
-`;
-
-const DelteButton = styled.button({
-  backgroundColor: 'gray',
-  color: 'white',
-  fontWeight: 'bold',
-  marginTop: '10px',
-  padding: '0.5rem 1rem',
-  fontSize: '1rem',
-  textAlign: 'center',
-  textDecoration: 'none',
-  display: 'inline-block',
-  width: 'auto',
-  border: 'none',
-  borderRadius: '4px',
-});
+import {
+  Table,
+  Thead,
+  Tbody,
+  DelteButton,
+} from '../../styles/CartPageStyle';
 
 export default function CartItemTable({ cart, onChangeCheckBox, onClickDeleteButton }) {
   return (

--- a/src/pages/CartPage.jsx
+++ b/src/pages/CartPage.jsx
@@ -1,22 +1,11 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import styled from '@emotion/styled';
 
 import CartContainer from '../components/cart/CartContainer';
 import Layout from '../components/layout/Layout';
+import { Notice, Container } from '../styles/CartPageStyle';
 import { get } from '../util/commonUtils';
 import { synchonizeCart } from '../redux/slice';
-
-const Notice = styled.p({
-  color: '#C14',
-});
-
-const Container = styled.div({
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'column',
-  justifyContent: 'space-between',
-});
 
 export default function CartPage() {
   const dispatch = useDispatch();

--- a/src/styles/CartPageStyle.jsx
+++ b/src/styles/CartPageStyle.jsx
@@ -1,0 +1,123 @@
+import styled from '@emotion/styled';
+
+const Notice = styled.p({
+  color: '#C14',
+});
+
+const Container = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
+  justifyContent: 'space-between',
+});
+
+const Table = styled.table`
+  min-width: 700px;
+  margin-top: 40px;
+  position: relative;
+`;
+const Thead = styled.thead({
+  backgroundColor: '#ccc',
+  height: '40px',
+  fontWeight: 'bold',
+  fontSize: '17px',
+});
+const Tbody = styled.tbody`
+  text-align: center;
+  padding: 10px 0;
+  height: 20px;
+  font-size: 14px;
+`;
+
+const ItemRow = styled.tr({
+  height: '100px',
+  marginTop: '10px',
+  display: 'flow',
+  '& div': {
+    maxWidth: '500px',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    alignItems: 'center',
+    '& img': {
+      margin: '10px',
+      width: '70px',
+    },
+    '& p': {
+      width: '300px',
+      whiteSpace: 'nowrap',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      display: 'block',
+      color: '#333',
+      textDecoration: 'none',
+      textAlign: 'center',
+      fontWeight: 'bolder',
+    },
+  },
+});
+
+const DelteButton = styled.button({
+  backgroundColor: 'gray',
+  color: 'white',
+  fontWeight: 'bold',
+  marginTop: '10px',
+  padding: '0.5rem 1rem',
+  fontSize: '1rem',
+  textAlign: 'center',
+  textDecoration: 'none',
+  display: 'inline-block',
+  width: 'auto',
+  border: 'none',
+  borderRadius: '4px',
+});
+
+const AmountBoxGruop = styled.div({
+  width: '700px',
+  display: 'flex',
+  direction: 'row',
+  justifyContent: 'space-around',
+  marginTop: '40px',
+});
+
+const AmountBox = styled.div({
+  maxWidth: '100px',
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  '& p': {
+    fontsize: '2em',
+  },
+  '& span': {
+    fontWeight: 'bolder',
+    fontsize: '1em',
+  },
+});
+
+const OrderButton = styled.button({
+  backgroundColor: 'tomato',
+  color: 'white',
+  fontWeight: 'bold',
+  marginTop: '60px',
+  padding: '0.5rem 1rem',
+  fontSize: '1rem',
+  textAlign: 'center',
+  textDecoration: 'none',
+  display: 'inline-block',
+  width: '50%',
+  border: 'none',
+  borderRadius: '4px',
+});
+
+export {
+  Notice,
+  Container,
+  Table,
+  Thead,
+  Tbody,
+  DelteButton,
+  ItemRow,
+  AmountBoxGruop,
+  AmountBox,
+  OrderButton,
+};

--- a/src/util/commonUtils.js
+++ b/src/util/commonUtils.js
@@ -15,3 +15,11 @@ export function currencyFomater({ number = 0, currency = '원' }) {
 export function percentageCalculator({ total = 1, partOf = 1 }) {
   return `${Math.ceil((partOf / total) * 100)}%`;
 }
+
+export function getSum(numbers) {
+  const sum = numbers.reduce((x, y) => x + y, 0);
+  return sum;
+}
+export function getPrices(mCart) {
+  return mCart.map((item) => item.realPrice * item.itemAmount);
+}


### PR DESCRIPTION
1) 관련 컴포넌트 스타일 컴포넌트 분리 >styles/CartPageStyle.jsx

2)  cart/CartAmountGroup.jsx에 사용된 

getSum, getPrices 계산 함수의 위치를 commonUItils로 이동하였습니다.
나중에 주문내역 '상세보기 페이지' 에서도 같은 함수를 사용할 예정입니다.


오늘 할일
1) CSS 수정 : 가운데 정렬이였던 버튼이 왼쪽 정렬로 바뀌어서 디버깅 해야 합니다.
2) 리덕스 스토리지 디버깅 필요. (FIXME 표시) : 내용이 길어 이슈에 추가하겠습니다!


